### PR TITLE
Map should be lower case

### DIFF
--- a/scraperwiki.json
+++ b/scraperwiki.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "View on a Map",
+  "displayName": "View on a map",
   "description": "Get a bird's eye view of your data",
   "icon": "https://s3-eu-west-1.amazonaws.com/sw-icons/tool-icon-map.png",
   "color": "#b46106"


### PR DESCRIPTION
At least, for other tools, we don't capitalise, e.g. "View in a table"
