### PR TITLE
Update OpenStreetMap tile URL to use HTTPS

### DIFF
--- a/http/code.js
+++ b/http/code.js
@@ -327,7 +327,7 @@ $(function(){
 
   // DOM is ready. Create map.
   map = L.map('map').setView([53.4167, -3], 8)
-  L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
   }).addTo(map);
 


### PR DESCRIPTION
Change URL from  `osm.org` to `openstreetmap.org`.

This allows us to use HTTPS to retrieve the tiles and avoids mixed
content warnings in the browser.